### PR TITLE
fix: use remote URL for test samplesheet reads path

### DIFF
--- a/assets/test_data/samplesheet_test.csv
+++ b/assets/test_data/samplesheet_test.csv
@@ -1,2 +1,2 @@
 sample,reads
-sample-ERR14204918,assets/test_data/ERR14204918.fastq.gz
+sample-ERR14204918,https://raw.githubusercontent.com/Leilanasd/metaAMR-Plus/main/assets/test_data/ERR14204918.fastq.gz


### PR DESCRIPTION
Changed the reads path in the test samplesheet from a relative path to a remote GitHub URL.
The relative path caused validation errors when the pipeline was run from a directory other
than the pipeline directory.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/metaAMR-Plus/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the metaAMR-Plus _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
